### PR TITLE
Fix orden de reglas y duplicados en Lexico.l

### DIFF
--- a/src/TP/Primera_Entrega/Lexico.l
+++ b/src/TP/Primera_Entrega/Lexico.l
@@ -19,9 +19,9 @@ int k=0;
 void capturaTipo(char *);
 
 typedef struct {
-       		    char lexema[50]; 
-                char tipoDato[100];				
-                char  valor[30];	
+       		    char lexema[50];
+                char tipoDato[100];
+                char  valor[30];
 				char longitud[25];
 	            } tsimbolos;
 
@@ -29,8 +29,8 @@ tsimbolos ts[100]; //pila con lexemas para agregar a la TS, puede guardar 100 le
 
 %}
 
-%option noyywrap  
-%option yylineno 
+%option noyywrap
+%option yylineno
 
 DIGITO		 	[0-9]
 LETRA 			[a-zA-Z]
@@ -40,7 +40,7 @@ CTE_INT      	{DIGITO}+
 CTE_REAL		{DIGITO}+"."{DIGITO}+|{DIGITO}*"."{DIGITO}+|{DIGITO}+"."{DIGITO}*
 COMILLAS	   	"\""
 ESPACIO			" "
-CTE_STR         \"[^\n]+\" 
+CTE_STR         \"[^\n]+\"
 COMENT_SIMPLE	"-/"({LETRA}|{DIGITO}|_|{ESPACIO}|":"|"="|"."|"+"|"("|")"|"["|"]"|",")*"/-"
 COMENT_DOBLE	"-/"({LETRA}|{DIGITO}|_|{ESPACIO}|":"|"="|"."|"+"|"("|")"|"["|"]"|","|{COMENT_SIMPLE})*"/-"
 
@@ -55,7 +55,7 @@ ELSE   			"ELSE"|"else"|"Else"
 WHILE  			"WHILE"|"while"|"While"
 ENDWHILE 		"ENDWHILE"|"endwhile"|"Endwhile"
 DECVAR 			"DECVAR"|"decvar"|"Decvar"
-ENDDEC 			"ENDDEC"|"enddec"|"Enddec" 
+ENDDEC 			"ENDDEC"|"enddec"|"Enddec"
 
 AND				"AND"|"and"|"And"
 OR				"OR"|"or"|"Or"
@@ -65,7 +65,29 @@ WRITE 			"WRITE"|"write"|"Write"
 READ 			"READ"|"read"|"Read"
 
 %%
-	
+
+","				{ return COMA;}
+";"				{ return PUNTO_COMA;}
+":="			{ return OPE_ASIG; }
+":"				{ return DOS_PUNTOS; }
+"["				{ return C_A; }
+"]"				{ return C_C; }
+"+"				{ return OPE_SUM; }
+"-"				{ return OPE_RES; }
+"*"				{ return OPE_MUL; }
+"/"				{ return OPE_DIV; }
+"("				{ return P_A; }
+")"				{ return P_C; }
+"{"				{ return L_A; }
+"}"				{ return L_C; }
+
+"=="			{ return IGUAL; }
+"<>"			{ return DIST; }
+"<"				{ return MENOR; }
+">"				{ return MAYOR; }
+"<="			{ return MEN_IG; }
+">="			{ return MAY_IG; }
+
 {FLOAT}			{capturaTipo(yytext); return FLOAT; }
 {INTEGER}		{capturaTipo(yytext);return INTEGER; }
 {STRING}		{capturaTipo(yytext);return STRING;}
@@ -76,7 +98,6 @@ READ 			"READ"|"read"|"Read"
 {AND}      	 	{ return AND; }
 {OR}        	{ return OR; }
 {NOT}       	{ return NOT; }
-{ENDIF}			{ return ENDIF; }
 {WHILE}        	{ return WHILE; }
 {ENDWHILE}     	{ return ENDWHILE; }
 {DECVAR}		{ return DECVAR; }
@@ -85,13 +106,6 @@ READ 			"READ"|"read"|"Read"
 {READ}	    	{ return READ; }
 {COMENT_SIMPLE}	{  }
 {COMENT_DOBLE}	{  }
-
-"=="			{ return IGUAL; }
-"<>"			{ return DIST; }
-"<"				{ return MENOR; }
-">"				{ return MAYOR; }
-"<="			{ return MEN_IG; }
-">="			{ return MAY_IG; }
 
 {CTE_STR}		{
                     int longitud=strlen(yytext);
@@ -106,32 +120,32 @@ READ 			"READ"|"read"|"Read"
 						printf("Cte string fuera de rango.\n");
 						system ("Pause");
 						exit(1);
-					} 
+					}
 			    }
 
-{CTE_INT}		{	int num = atoi(yytext); 
-					
+{CTE_INT}		{	int num = atoi(yytext);
+
 					if(num >= 0 && num <= 65535){
-						
+
 						 guardarLexemas(yytext,2);
-						  
-						return CTE_INT; 
+
+						return CTE_INT;
 					}
 					else	{
 						printf("-------------ERROR-------------\n");
 						printf("Integer fuera de rango.\n");
 						system ("Pause");
 						exit(1);
-					} 
+					}
 				}
-				
+
 {CTE_REAL}	{	double num = atof(yytext);
 					double cotaMayor = (3.4)*(exp(38));
-					
+
 					if(num >= 0 && num <= cotaMayor){
 					 guardarLexemas(yytext,3);
-					 
-						return CTE_REAL; 
+
+						return CTE_REAL;
 					}
 					else{
 						printf("-------------ERROR-------------\n");
@@ -143,36 +157,20 @@ READ 			"READ"|"read"|"Read"
 
 {ID}     	{guardarLexemas(yytext,0);return ID; }
 
-","			{ return COMA;}
-";"			{ return PUNTO_COMA;}
-":="		{ return OPE_ASIG; }
-":"			{ return DOS_PUNTOS; }
-"["			{ return C_A; }
-"]"			{ return C_C; }
-","			{ return COMA; }
-"+"			{ return OPE_SUM; }
-"-"			{ return OPE_RES; }
-"*"			{ return OPE_MUL; }
-"/"			{ return OPE_DIV; }
-"("			{ return P_A; }
-")"			{ return P_C; }
-"{"			{ return L_A; }
-"}"			{ return L_C; }
-
-"\n"      		
+"\n"
 "\t"
-" "	
-"\r\n" 
+" "
+"\r\n"
 
 %%
 
 void guardarTS_Archivo()
 {
-FILE* arch; 
+FILE* arch;
 int x;
- 
+
     arch = fopen("ts.txt", "w+");
-	
+
 	if (!arch){
 		printf("Error. No se pudo crear el archivo ts.txt");
 	exit(1);
@@ -183,20 +181,20 @@ int x;
 	fprintf(arch,"%-23s%-15s%-20s%8s",ts[x].lexema,ts[x].tipoDato,ts[x].valor,ts[x].longitud);
 	fprintf(arch,"\n");
 	}
-    
-	 fclose(arch);    
+
+	 fclose(arch);
 }
- 
+
 void guardarLexemas(char *lexema,int val)
 {
-  
+
     if(val==0)
 	{
 	   if(buscar(lexema)!=0)
 	   {
 	      strcpy(ts[i].lexema,lexema);
 		  i++;//incremento para conocer la cantidad de id que hay en la ctes
-	   } 
+	   }
 	}
 
     if(val==1)
@@ -205,22 +203,22 @@ void guardarLexemas(char *lexema,int val)
 		*s++;//adelanto el puntero para que no tome la 1eras comillas
 		int n=strlen(lexema)-2;//le resto 2 para que no copie las comillas (iniciales y finales)
 		strncpy(lexema,s,n);
-		while(n > 1)//llevo el puntero hasta la posicion que debe finalizar el string 
+		while(n > 1)//llevo el puntero hasta la posicion que debe finalizar el string
 		{
 			n--;
 		    s++;
 		}
 	    memset(s, '\0',n);//marco el fin del string
-		
+
 	  	if(buscar(lexema)!=0)
 	 	{
 			strcpy(ts[i].lexema,"_");
 			strcat(ts[i].lexema,lexema);;
 			strcpy(ts[i].valor,lexema);
-			itoa(strlen(lexema),ts[i].longitud,10);	
-			i++;//incremento para conocer la cantidad de id que hay en la ctes				   
+			itoa(strlen(lexema),ts[i].longitud,10);
+			i++;//incremento para conocer la cantidad de id que hay en la ctes
       	}
-	} 
+	}
 
     if(val==2)
 	{
@@ -232,7 +230,7 @@ void guardarLexemas(char *lexema,int val)
 			i++;//incremento para conocer la cantidad de id que hay en la ctes
 		}
 	}
-    
+
 	if(val==3)
 	{
 		if(buscar(lexema)!=0)
@@ -242,15 +240,15 @@ void guardarLexemas(char *lexema,int val)
 			strcpy(ts[i].valor,lexema);
 			i++;//incremento para conocer la cantidad de id que hay en la ctes
 		}
-	}	
+	}
 }
 
 int buscar(char * lexema)
 {
  int x;
   for(x=0;x<i;x++){//50 cantidad de lexemas en la tabla
-  if(strcmp(ts[x].lexema,lexema)==0)  
-   return 0;  
+  if(strcmp(ts[x].lexema,lexema)==0)
+   return 0;
   }
    return 1;
 }


### PR DESCRIPTION
## Cambios
- Se reordenaron los patrones que matchean con signos de puntuación para evitar conflictos con las siguientes reglas
- Se quitaron reglas duplicadas.
- Se quitó espaciado de más